### PR TITLE
fix: keep config hub closed on subwindow save

### DIFF
--- a/scripts/camera-config-app.js
+++ b/scripts/camera-config-app.js
@@ -263,28 +263,33 @@ export class CameraConfigApp extends foundry.applications.api.ApplicationV2 {
     });
   }
 
+  async refreshIfOpen() {
+    if (!document.getElementById(this.scopedId("hub-form"))) return;
+    await this.render(true);
+  }
+
   openLayoutConfig() {
     if (!this.selectedUserId) return;
-    new LayoutConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.render(true) }).render(true);
+    new LayoutConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.refreshIfOpen() }).render(true);
   }
 
   openEffectsConfig() {
     if (!this.selectedUserId) return;
-    new EffectsConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.render(true) }).render(true);
+    new EffectsConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.refreshIfOpen() }).render(true);
   }
 
   openOverlayConfig() {
     if (!this.selectedUserId) return;
-    new OverlayConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.render(true) }).render(true);
+    new OverlayConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.refreshIfOpen() }).render(true);
   }
 
   openNameConfig() {
     if (!this.selectedUserId) return;
-    new NameConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.render(true) }).render(true);
+    new NameConfigApp({ selectedUserId: this.selectedUserId, onSaved: () => this.refreshIfOpen() }).render(true);
   }
 
   openScenePresets() {
-    new SceneLayoutPresetApp({ onSaved: () => this.render(true) }).render(true);
+    new SceneLayoutPresetApp({ onSaved: () => this.refreshIfOpen() }).render(true);
   }
 
   openSupportReport() {

--- a/scripts/camera-config-shared.js
+++ b/scripts/camera-config-shared.js
@@ -102,6 +102,11 @@ export function setFieldValue(form, name, value) {
   field.value = String(value ?? "");
 }
 
+export async function finalizeSubwindowSave(app, onSaved) {
+  if (typeof app?.close === "function") await app.close();
+  if (typeof onSaved === "function") await onSaved();
+}
+
 export function loadLayoutForUser(selectedUserId) {
   const sceneId = currentSceneId();
   const draftLayouts = loadedDraftLayouts(sceneId);

--- a/scripts/effects-config-app.js
+++ b/scripts/effects-config-app.js
@@ -2,7 +2,7 @@ import { MODULE_ID } from "./constants.js";
 import { buildFormData, buildLayoutPatch } from "./camera-config-model.js";
 import { replaceAppContent } from "./dom-replace.js";
 import { appId, bindEffectEditor, effectEditor, rowWithHelp, sectionHtml, textInput } from "./camera-config-ui.js";
-import { currentSceneId, loadLayoutForUser, localize, saveLayoutPatchForUser, selectedUser, usersForConfig } from "./camera-config-shared.js";
+import { currentSceneId, finalizeSubwindowSave, loadLayoutForUser, localize, saveLayoutPatchForUser, selectedUser, usersForConfig } from "./camera-config-shared.js";
 
 function titleKey() {
   return `${MODULE_ID}.ui.effects.title`;
@@ -104,7 +104,7 @@ export class EffectsConfigApp extends foundry.applications.api.ApplicationV2 {
     delete patch.overlay;
     delete patch.nameStyle;
     await saveLayoutPatchForUser(this.selectedUserId, patch);
-    if (this.onSaved) this.onSaved();
+    await finalizeSubwindowSave(this, this.onSaved);
     ui.notifications.info(localize("ui.config.notifications.saved"));
     console.debug(`${MODULE_ID} | effects config saved`, {
       playerId: this.selectedUserId,

--- a/scripts/layout-config-app.js
+++ b/scripts/layout-config-app.js
@@ -4,6 +4,7 @@ import { replaceAppContent } from "./dom-replace.js";
 import { appId, helpText, rowHtml, rowWithHelp, sectionHtml, textInput } from "./camera-config-ui.js";
 import {
   currentSceneId,
+  finalizeSubwindowSave,
   loadLayoutForUser,
   loadedDraftCameraControlMode,
   loadedDraftLayouts,
@@ -339,7 +340,7 @@ export class LayoutConfigApp extends foundry.applications.api.ApplicationV2 {
     delete patch.nameStyle;
     delete patch.geometry;
     await saveLayoutPatchForUser(this.selectedUserId, patch);
-    if (this.onSaved) this.onSaved();
+    await finalizeSubwindowSave(this, this.onSaved);
     ui.notifications.info(localize("ui.config.notifications.saved"));
     console.debug(`${MODULE_ID} | layout config saved`, { playerId: this.selectedUserId, patch });
   }

--- a/scripts/name-config-app.js
+++ b/scripts/name-config-app.js
@@ -2,7 +2,7 @@ import { MODULE_ID } from "./constants.js";
 import { buildFormData, buildNameStylePatch } from "./camera-config-model.js";
 import { replaceAppContent } from "./dom-replace.js";
 import { appId, checkboxInput, colorInput, rowWithHelp, sectionHtml, selectFromItems, textInput } from "./camera-config-ui.js";
-import { loadLayoutForUser, localize, readChecked, readText, saveLayoutPatchForUser, selectedUser, usersForConfig } from "./camera-config-shared.js";
+import { finalizeSubwindowSave, loadLayoutForUser, localize, readChecked, readText, saveLayoutPatchForUser, selectedUser, usersForConfig } from "./camera-config-shared.js";
 
 function titleKey() {
   return `${MODULE_ID}.ui.name.title`;
@@ -273,7 +273,7 @@ export class NameConfigApp extends foundry.applications.api.ApplicationV2 {
     if (!this.selectedUserId) return;
     const patch = buildNameStylePatch(readFormData(form));
     await saveLayoutPatchForUser(this.selectedUserId, patch);
-    if (this.onSaved) this.onSaved();
+    await finalizeSubwindowSave(this, this.onSaved);
     ui.notifications.info(localize("ui.config.notifications.saved"));
     console.debug(`${MODULE_ID} | name config saved`, { playerId: this.selectedUserId, patch });
   }

--- a/scripts/overlay-config-app.js
+++ b/scripts/overlay-config-app.js
@@ -18,6 +18,7 @@ import {
 } from "./camera-config-ui.js";
 import {
   currentSceneId,
+  finalizeSubwindowSave,
   loadLayoutForUser,
   localize,
   readText,
@@ -227,7 +228,7 @@ export class OverlayConfigApp extends foundry.applications.api.ApplicationV2 {
     delete patch.nameStyle;
     delete patch.geometry;
     await saveLayoutPatchForUser(this.selectedUserId, patch);
-    if (this.onSaved) this.onSaved();
+    await finalizeSubwindowSave(this, this.onSaved);
     ui.notifications.info(localize("ui.config.notifications.saved"));
     console.debug(`${MODULE_ID} | overlay config saved`, {
       playerId: this.selectedUserId,

--- a/scripts/scene-layout-preset-app.js
+++ b/scripts/scene-layout-preset-app.js
@@ -1,7 +1,7 @@
 import { DEFAULT_CAMERA_BOUNDS, MODULE_ID } from "./constants.js";
 import { replaceAppContent } from "./dom-replace.js";
 import { appId, checkboxInput, numberInput, rowWithHelp, sectionHtml, selectFromItems } from "./camera-config-ui.js";
-import { currentSceneId, localize, usersForConfig } from "./camera-config-shared.js";
+import { currentSceneId, finalizeSubwindowSave, localize, usersForConfig } from "./camera-config-shared.js";
 import { getAllPlayerLayouts } from "./camera-style-service.js";
 import { applyCameraLayoutsNow } from "./live-camera-renderer.js";
 import { buildSceneLayoutPreset, getNarrativeSceneLayoutPresetIds } from "./scene-layout-presets.js";
@@ -274,7 +274,7 @@ export class SceneLayoutPresetApp extends foundry.applications.api.ApplicationV2
 
     await applySceneProfile(sceneId, baseLayouts, { cameraControlMode: "module" });
     applyCameraLayoutsNow();
-    if (this.onSaved) this.onSaved();
+    await finalizeSubwindowSave(this, this.onSaved);
 
     if (built.ignoredUserIds.length > 0) {
       ui.notifications.warn(localize("ui.scenePresets.notifications.partial").replace("{count}", String(built.ignoredUserIds.length)));

--- a/tests/unit/camera-config-app.test.js
+++ b/tests/unit/camera-config-app.test.js
@@ -157,3 +157,83 @@ test("camera config exportCurrentLayout exports scene macro with scene control m
   assert.equal(createdMacro.command.includes('"top": "10px"'), true);
   assert.equal(createdMacro.command.includes('"left": "20px"'), true);
 });
+
+test("camera config refreshIfOpen does not reopen the hub when it is closed", async () => {
+  globalThis.game = {
+    i18n: {
+      localize: (key) => key
+    },
+    user: {
+      id: "u1"
+    }
+  };
+  globalThis.document = {
+    getElementById: () => null
+  };
+  globalThis.foundry = {
+    utils: {
+      escapeHTML: (value) => String(value ?? "")
+    },
+    applications: {
+      api: {
+        ApplicationV2: class {
+          constructor() {
+            this.id = "app-1";
+          }
+        }
+      }
+    }
+  };
+
+  const { CameraConfigApp } = await import("../../scripts/camera-config-app.js");
+
+  const app = new CameraConfigApp();
+  let renderCount = 0;
+  app.render = async () => {
+    renderCount += 1;
+  };
+
+  await app.refreshIfOpen();
+
+  assert.equal(renderCount, 0);
+});
+
+test("camera config refreshIfOpen rerenders the hub when it is still open", async () => {
+  globalThis.game = {
+    i18n: {
+      localize: (key) => key
+    },
+    user: {
+      id: "u1"
+    }
+  };
+  globalThis.document = {
+    getElementById: () => ({})
+  };
+  globalThis.foundry = {
+    utils: {
+      escapeHTML: (value) => String(value ?? "")
+    },
+    applications: {
+      api: {
+        ApplicationV2: class {
+          constructor() {
+            this.id = "app-2";
+          }
+        }
+      }
+    }
+  };
+
+  const { CameraConfigApp } = await import("../../scripts/camera-config-app.js");
+
+  const app = new CameraConfigApp();
+  let renderCount = 0;
+  app.render = async () => {
+    renderCount += 1;
+  };
+
+  await app.refreshIfOpen();
+
+  assert.equal(renderCount, 1);
+});

--- a/tests/unit/camera-config-shared.test.js
+++ b/tests/unit/camera-config-shared.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { normalizeImportPayload, resetLayoutForUser, sanitizeLayoutForCameraControlMode, sanitizeLayouts } from "../../scripts/camera-config-shared.js";
+import { finalizeSubwindowSave, normalizeImportPayload, resetLayoutForUser, sanitizeLayoutForCameraControlMode, sanitizeLayouts } from "../../scripts/camera-config-shared.js";
 import { clearLoadedSceneProfileDraft } from "../../scripts/state.js";
 
 function installSettings(initial) {
@@ -207,4 +207,19 @@ test("resetLayoutForUser keeps native scenes free of module geometry", async () 
   assert.equal(changed, true);
   assert.deepEqual(store.playerLayouts, {});
   assert.equal(store.sceneProfiles["scene-a"], undefined);
+});
+
+test("finalizeSubwindowSave closes the subwindow and then refreshes the hub callback", async () => {
+  const events = [];
+  const app = {
+    close: async () => {
+      events.push("close");
+    }
+  };
+
+  await finalizeSubwindowSave(app, async () => {
+    events.push("saved");
+  });
+
+  assert.deepEqual(events, ["close", "saved"]);
 });


### PR DESCRIPTION
## Summary
- keep the config hub closed if the user had already closed it before saving a subwindow
- close Layout, Effects, Overlay, Name, and Scene Presets subwindows after a successful save
- centralize the post-save window flow so the hub only refreshes when it is still open

## Root Cause
Subwindows always called back into the hub with `this.render(true)`, so saving from a child window reopened the hub even when the user had closed it. The child windows also stayed open because the save flow never closed them after a successful write.

## Testing
- `npm test`

Closes #16